### PR TITLE
removes seating chart from being instantiated statically

### DIFF
--- a/client/index.jsx
+++ b/client/index.jsx
@@ -217,7 +217,6 @@ class App extends React.Component {
         <div className="container">
           {seating}
           {main}
-          <SeatingChart/>
           {list}
         </div>
       </div>


### PR DESCRIPTION
One of the recent pull requests/merges included a static version of the seating chart in between the main and list sections of index.jsx. This removes that instance.